### PR TITLE
replace let* with let when possible

### DIFF
--- a/op-enhance.el
+++ b/op-enhance.el
@@ -30,10 +30,10 @@
 
 (defun op/prepare-theme (pub-root-dir)
   "Copy theme files to PUB-ROOT-DIR."
-  (let* ((pub-theme-dir (expand-file-name "media/" pub-root-dir))
-         (theme-dir (file-name-as-directory
-                     (expand-file-name (symbol-name op/theme)
-                                       op/theme-directory))))
+  (let ((pub-theme-dir (expand-file-name "media/" pub-root-dir))
+        (theme-dir (file-name-as-directory
+                    (expand-file-name (symbol-name op/theme)
+                                      op/theme-directory))))
     (unless (file-directory-p theme-dir)
       (message "Theme %s not found, use `default' theme instead."
                (symbol-name op/theme))
@@ -74,7 +74,7 @@ new theme."
 (defun op/generate-page-header ()
   "Generate page header, based on the template defined by
 `op/html-header-template', please see its description for more detail."
-  (let* ((search-url op/site-url))
+  (let ((search-url op/site-url))
     (when (string-match "\\`https?://\\(.*[a-zA-Z]\\)/?\\'" op/site-url)
       (setq search-url (match-string 1 op/site-url)))
     (format-spec op/html-header-template `((?m . ,op/site-main-title)
@@ -88,9 +88,9 @@ new theme."
 
 (defun op/generate-style ()
   "Generate css style links."
-  (let* ((template "<link href=\"%s\" rel=\"stylesheet\" type=\"text/css\" />")
-         (css-list op/css-list)
-         css-links)
+  (let ((template "<link href=\"%s\" rel=\"stylesheet\" type=\"text/css\" />")
+        (css-list op/css-list)
+        css-links)
     (unless css-list
       (setq css-list '("main.css")))
     (mapconcat '(lambda (css)

--- a/op-export.el
+++ b/op-export.el
@@ -93,9 +93,9 @@ The URI-TEMPLATE can contain following parameters:
 %y: year of creation date
 %m: month of creation date
 %d: day of creation date"
-  (let* ((date-list (split-string creation-date "-"))
-         (encoded-title (convert-string-to-path title))
-         uri)
+  (let ((date-list (split-string creation-date "-"))
+        (encoded-title (convert-string-to-path title))
+        uri)
     (setq uri (cond
                ((eq category 'index) "/")
                ((eq category 'about) "/about/") ; TODO customization
@@ -258,8 +258,8 @@ publication directory. EXT-PLIST is the property list will be passed to
   "Generate default about page, only if about.org does not exist. PUB-BASE-DIR
 is the root publication directory. EXT-PLIST is the property list will be passed
 to `op/export-as-html'."
-  (let* ((author-name (or user-full-name "[author]"))
-         (pub-dir (expand-file-name "about/" pub-base-dir)))
+  (let ((author-name (or user-full-name "[author]"))
+        (pub-dir (expand-file-name "about/" pub-base-dir)))
     (with-current-buffer (get-buffer-create op/temp-buffer-name)
       (erase-buffer)
       (insert "#+TITLE: About" "\n\n")


### PR DESCRIPTION
Using let instead let\* when possible is a good coding style, at least in
Common Lisp. Actually, let may have better performance since let can do
parallel assignment, while let\* can only do sequential assignment.
