### PR TITLE
move css-related code to template

### DIFF
--- a/op-enhance.el
+++ b/op-enhance.el
@@ -86,17 +86,6 @@ new theme."
                                            (?g . ,op/personal-github-link)
                                            (?u . ,search-url)))))
 
-(defun op/generate-style ()
-  "Generate css style links."
-  (let ((template "<link href=\"%s\" rel=\"stylesheet\" type=\"text/css\" />")
-        (css-list op/css-list)
-        css-links)
-    (unless css-list
-      (setq css-list '("main.css")))
-    (mapconcat '(lambda (css)
-                  (format template (concat "/media/css/" css))) ;; TODO customization
-               css-list "\n")))
-
 (defun op/generate-footer (uri attr-plist hide-meta-info hide-comment)
   "Generate page footer, based on the template defined by
 `op/html-postamble-template', please see its description for more detail."

--- a/op-export.el
+++ b/op-export.el
@@ -40,11 +40,7 @@ deleted. PUB-ROOT-DIR is the root publication directory."
   (let* ((upd-list (plist-get change-plist :update))
          (del-list (plist-get change-plist :delete))
          (header (op/generate-page-header))
-         (style (op/generate-style))
-         (ext-plist `(:style ,style
-                      :html-preamble ,header
-                      :style-include-default nil
-                      :style-include-scripts nil))
+         (ext-plist `(:html-preamble ,header))
          visiting file-buffer file-attr-list)
     (when (or upd-list del-list)
       (mapc

--- a/op-hack.el
+++ b/op-hack.el
@@ -72,13 +72,6 @@ PUB-DIR is set, use this as the publishing directory."
                                ext-plist
                                (org-infile-export-plist))))
          (body-only (or body-only (plist-get opt-plist :body-only)))
-         (style (concat (if (plist-get opt-plist :style-include-default)
-                            org-export-html-style-default)
-                        (plist-get opt-plist :style)
-                        (plist-get opt-plist :style-extra)
-                        "\n"
-                        (if (plist-get opt-plist :style-include-scripts)
-                            org-export-html-scripts)))
          (html-extension (plist-get opt-plist :html-extension))
          valid thetoc have-headings first-heading-pos
          (odd org-odd-levels-only)
@@ -289,7 +282,7 @@ PUB-DIR is set, use this as the publishing directory."
 <meta name=\"author\" content=\"%s\"/>
 <meta name=\"description\" content=\"%s\"/>
 <meta name=\"keywords\" content=\"%s\"/>
-%s
+<link href=\"/media/css/main.css\" rel=\"stylesheet\" type=\"text/css\" />
 %s
 </head>
 <body>
@@ -311,7 +304,6 @@ PUB-DIR is set, use this as the publishing directory."
                  ;(or charset "iso-8859-1")
                  (or charset "utf-8")
                  title date author description keywords
-                 style
                  mathjax
                  (if (or link-up link-home)
                      (concat

--- a/op-vars.el
+++ b/op-vars.el
@@ -117,10 +117,6 @@ presented by `op/repository-directory'."
 %u: the url of current site, used for search (defined by `op/site-url')"
   :group 'org-page :type 'string)
 
-(defcustom op/css-list '("main.css")
-  "CSS style file name list, will using uri \"/media/css/<name>\"."
-  :group 'org-page :type 'list)
-
 (defcustom op/meta-info
   (file-to-string (concat op/load-directory
                           (format "templates/html/%s/meta-info-template.html"


### PR DESCRIPTION
CSS support file import, which means one css file can include other css
files, thus we can simply code by making the "main.css" file as the
default style for all themes and templates.
