### PR TITLE
remove op/theme-directory from op-vars.el

### DIFF
--- a/op-enhance.el
+++ b/op-enhance.el
@@ -28,19 +28,21 @@
 
 (require 'format-spec)
 
+(defun op/get-theme-dir (theme)
+  (file-name-as-directory
+   (expand-file-name (symbol-name op/theme)
+                     (expand-file-name "themes"
+                                       op/load-directory))))
+
 (defun op/prepare-theme (pub-root-dir)
   "Copy theme files to PUB-ROOT-DIR."
   (let ((pub-theme-dir (expand-file-name "media/" pub-root-dir))
-        (theme-dir (file-name-as-directory
-                    (expand-file-name (symbol-name op/theme)
-                                      op/theme-directory))))
+        (theme-dir (op/get-theme-dir op/theme)))
     (unless (file-directory-p theme-dir)
       (message "Theme %s not found, use `default' theme instead."
                (symbol-name op/theme))
       (setq op/theme 'default)
-      (setq theme-dir (file-name-as-directory
-                       (expand-file-name (symbol-name op/theme)
-                                         op/theme-directory))))
+      (setq theme-dir (op/get-theme-dir 'default)))
     (op/update-theme op/theme)
     (when (file-directory-p pub-theme-dir)
       (delete-directory pub-theme-dir t))

--- a/op-vars.el
+++ b/op-vars.el
@@ -93,11 +93,6 @@ http:// or https://, http will be considered if not assigned."
 presented by `op/repository-directory'."
   :group 'org-page :type 'string)
 
-(defcustom op/theme-directory
-  (expand-file-name "themes/" op/load-directory)
-  "The directory stores org-page styles/scripts/images."
-  :group 'org-page :type 'string)
-
 (defcustom op/theme 'default
   "The theme used for page generation."
   :group 'org-page :type 'symbol)

--- a/org-page.el
+++ b/org-page.el
@@ -118,7 +118,6 @@ files, committed by org-page.")
 (defun op/verify-configuration ()
   "Ensure all required configuration fields are properly configured, include:
 `op/repository-directory': <required>
-`op/theme-directory': <required> (but do not need user to configure)
 `op/site-url': <required>
 `op/personal-disqus-shortname': <required>
 `op/repository-org-branch': [optional] (but customization recommended)
@@ -133,11 +132,10 @@ files, committed by org-page.")
                (file-directory-p op/repository-directory))
     (error "Directory `%s' is not properly configured."
            (symbol-name 'op/repository-directory)))
-  (unless (and op/theme-directory
-               (file-directory-p op/theme-directory))
+  (unless (file-directory-p (op/get-theme-dir op/theme))
     (error "Org-page cannot detect theme directory `%s' automatically, please \
 help configure it manually, usually it should be <org-page directory>/themes/."
-           (symbol-name 'op/theme-directory)))
+           (symbol-name 'op/theme)))
   (unless op/site-url
     (error "Site url `%s' is not properly configured."
            (symbol-name 'op/site-url)))


### PR DESCRIPTION
Less is more, if a default options is good enough, then there's no need
to make it configurable. Second, the html template and theme files are
all static files, but there are two different ways in org-page to handle
html template and theme files, consistency should be keeped.
